### PR TITLE
Handle multiple fragments being shown at once

### DIFF
--- a/reveal-code-focus.js
+++ b/reveal-code-focus.js
@@ -18,10 +18,22 @@
     }
   }
 
+  function equalArrays(array1, array2) {
+    if (array1.length != array2.length) {
+      return false;
+    }
+    for (var i = 0; i < array1.length; ++i) {
+      if (array1[i] !== array2[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   function indexOf(array, elem) {
     var i = -1, length = array ? array.length : 0;
     while (++i < length) {
-      if (array[i] === elem) {
+      if (equalArrays(array[i], elem)) {
         return i;
       }
     }
@@ -90,15 +102,15 @@
     Reveal.addEventListener('slidechanged', updateCurrentSlide);
 
     Reveal.addEventListener('fragmentshown', function(e) {
-      focusFragment(e.fragment);
+      focusFragments(e.fragments);
     });
 
     // TODO: make this configurable.
     // When a fragment is hidden, clear the current focused fragment,
     // and focus on the previous fragment.
     Reveal.addEventListener('fragmenthidden', function(e) {
-      var index = indexOf(currentFragments, e.fragment);
-      focusFragment(currentFragments[index - 1]);
+      var index = indexOf(currentFragments, e.fragments);
+      focusFragments(currentFragments[index - 1]);
     });
 
     updateCurrentSlide(e);
@@ -106,7 +118,13 @@
 
   function updateCurrentSlide(e) {
     currentSlide = e.currentSlide;
-    currentFragments = currentSlide.getElementsByClassName('fragment');
+    currentFragments = [];
+    var fragments = currentSlide.getElementsByClassName('fragment');
+    forEach(fragments, function(fragment) {
+      var fragmentIndex = fragment.getAttribute('data-fragment-index');
+      currentFragments[fragmentIndex] = currentFragments[fragmentIndex] || [];
+      currentFragments[fragmentIndex].push(fragment);
+    });
     clearPreviousFocus();
 
     // If moving back to a previous slide…
@@ -121,8 +139,10 @@
       // …return to the last fragment and highlight the code.
       while (Reveal.nextFragment()) {}
       var currentFragment = currentFragments[currentFragments.length - 1];
-      currentFragment.classList.add('current-fragment');
-      focusFragment(currentFragment);
+      forEach(currentFragment, function (currentFragment) {
+        currentFragment.classList.add('current-fragment');
+      });
+      focusFragments(currentFragment);
     }
 
     // Update previous slide information.
@@ -139,81 +159,83 @@
     });
   }
 
-  function focusFragment(fragment) {
+  function focusFragments(fragments) {
     clearPreviousFocus();
-    if (!fragment) {
+    if (!fragments) {
       return;
     }
 
-    var lines = fragment.getAttribute('data-code-focus');
-    if (!lines) {
-      return;
-    }
-
-    var codeBlock = parseInt(fragment.getAttribute('data-code-block'));
-    if (isNaN(codeBlock)) {
-      codeBlock = 1;
-    }
-
-    var preElems = currentSlide.querySelectorAll('pre');
-    if (!preElems.length) {
-      return;
-    }
-
-    var pre = preElems[codeBlock - 1];
-    var code = pre.querySelectorAll('code .line');
-    if (!code.length) {
-      return;
-    }
-
-    var topLineNumber, bottomLineNumber;
-
-    forEach(lines.split(','), function(line) {
-      lines = line.split('-');
-      if (lines.length == 1) {
-        focusLine(lines[0]);
-      } else {
-        var i = lines[0] - 1, j = lines[1];
-
-        while (++i <= j) {
-          focusLine(i);
-        }
-      }
-    });
-
-    function focusLine(lineNumber) {
-      // Convert from 1-based index to 0-based index.
-      lineNumber -= 1;
-
-      var line = code[lineNumber];
-      if (!line) {
+    forEach(fragments, function(fragment) {
+      var lines = fragment.getAttribute('data-code-focus');
+      if (!lines) {
         return;
       }
 
-      line.classList.add('focus');
+      var codeBlock = parseInt(fragment.getAttribute('data-code-block'));
+      if (isNaN(codeBlock)) {
+        codeBlock = 1;
+      }
 
-      if (scrollToFocused) {
-        if (topLineNumber == null) {
-          topLineNumber = bottomLineNumber = lineNumber;
+      var preElems = currentSlide.querySelectorAll('pre');
+      if (!preElems.length) {
+        return;
+      }
+
+      var pre = preElems[codeBlock - 1];
+      var code = pre.querySelectorAll('code .line');
+      if (!code.length) {
+        return;
+      }
+
+      var topLineNumber, bottomLineNumber;
+
+      forEach(lines.split(','), function(line) {
+        lines = line.split('-');
+        if (lines.length == 1) {
+          focusLine(lines[0]);
         } else {
-          if (lineNumber < topLineNumber) {
-            topLineNumber = lineNumber;
+          var i = lines[0] - 1, j = lines[1];
+
+          while (++i <= j) {
+            focusLine(i);
           }
-          if (lineNumber > bottomLineNumber) {
-            bottomLineNumber = lineNumber;
+        }
+      });
+
+      function focusLine(lineNumber) {
+        // Convert from 1-based index to 0-based index.
+        lineNumber -= 1;
+
+        var line = code[lineNumber];
+        if (!line) {
+          return;
+        }
+
+        line.classList.add('focus');
+
+        if (scrollToFocused) {
+          if (topLineNumber == null) {
+            topLineNumber = bottomLineNumber = lineNumber;
+          } else {
+            if (lineNumber < topLineNumber) {
+              topLineNumber = lineNumber;
+            }
+            if (lineNumber > bottomLineNumber) {
+              bottomLineNumber = lineNumber;
+            }
           }
         }
       }
-    }
 
-    if (scrollToFocused && topLineNumber != null) {
-      var topLine =  code[topLineNumber];
-      var bottomLine = code[bottomLineNumber];
-      var codeParent = topLine.parentNode;
-      var scrollTop = topLine.offsetTop;
-      var scrollBottom = bottomLine.offsetTop + bottomLine.clientHeight;
-      codeParent.scrollTop = scrollTop - (codeParent.clientHeight - (scrollBottom - scrollTop)) / 2;
-    }
+      if (scrollToFocused && topLineNumber != null) {
+        var topLine =  code[topLineNumber];
+        var bottomLine = code[bottomLineNumber];
+        var codeParent = topLine.parentNode;
+        var scrollTop = topLine.offsetTop;
+        var scrollBottom = bottomLine.offsetTop + bottomLine.clientHeight;
+        codeParent.scrollTop = scrollTop - (codeParent.clientHeight - (scrollBottom - scrollTop)) / 2;
+      }
+    });
   }
 
   function RevealCodeFocus(options) {


### PR DESCRIPTION
Reveal.js allows multiple fragments to be assigned the same data-fragment-index,
meaning that they are shown simultaneously. Focus all lines mentioned in all
fragments that are shown.