### PR TITLE
Fix focusing last line when using data-trim

### DIFF
--- a/reveal-code-focus.js
+++ b/reveal-code-focus.js
@@ -40,7 +40,7 @@
     forEach(document.querySelectorAll('pre code'), function(element) {
       // Trim whitespace if the `data-trim` attribute is present.
       if (element.hasAttribute('data-trim') && typeof element.innerHTML.trim == 'function') {
-        element.innerHTML = element.innerHTML.trim();
+        element.innerHTML = element.innerHTML.trim() + "\n";
       }
 
       // Highlight code using highlight.js.


### PR DESCRIPTION
The last line was not being wrapped in a <span> when using data-trim because the
trailing newline was removed. Add a trailing newline.